### PR TITLE
增加parse参数，不改变postcss的ast结构

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ module.exports = postcss.plugin('postcss-px2rem', function (options) {
     var oldCssText = css.toString();
     var px2remIns = new Px2rem(options);
     var newCssText = px2remIns.generateRem(oldCssText);
-    var newCssObj = postcss.parse(newCssText);
+    var newCssObj = postcss.parse(newCssText, result.opts|| {});
     result.root = newCssObj;
   };
 });


### PR DESCRIPTION
详细起因经过点这里：https://github.com/vitejs/vite/pull/7186
这里是简要描述：
1. postcss的parse一般会接受参数opts，并且生成的ast的某些值依赖opts https://github.com/postcss/postcss/blob/24f2efc9a36d31c7a0cdf884804d3cfaea024be2/lib/parse.js#L7
2. 我们这里没有传opts，导致ast少了属性`input.file`,而我在用的`vite`里的`vite-url-plugin`插件强依赖了这个属性导致最终打包出问题
3. 我觉得ast还是不应该受到影响的，所以做了这个修改

感谢大佬